### PR TITLE
Fix ARM64 compatibility for hasura CLI installation

### DIFF
--- a/src/bdjuno/bdjuno_launcher.star
+++ b/src/bdjuno/bdjuno_launcher.star
@@ -165,8 +165,13 @@ def launch_hasura_service(plan, postgres_service, chain_name, hasura_metadata_ar
                 """
                 sleep 30
                 
-                # Install hasura CLI
-                curl -L https://github.com/hasura/graphql-engine/releases/latest/download/cli-hasura-linux-amd64 -o /usr/local/bin/hasura
+                # Install hasura CLI - detect architecture and download appropriate binary
+                ARCH=$(uname -m)
+                if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+                    curl -L https://github.com/hasura/graphql-engine/releases/latest/download/cli-hasura-linux-arm64 -o /usr/local/bin/hasura
+                else
+                    curl -L https://github.com/hasura/graphql-engine/releases/latest/download/cli-hasura-linux-amd64 -o /usr/local/bin/hasura
+                fi
                 chmod +x /usr/local/bin/hasura
                 
                 cd /hasura


### PR DESCRIPTION
- Add architecture detection using uname -m
- Download cli-hasura-linux-arm64 for ARM64/aarch64 systems
- Download cli-hasura-linux-amd64 for x86_64 systems
- Resolves 'rosetta error: failed to open elf' on ARM64 platforms
- Ensures hasura metadata apply works correctly on all architectures