### PR TITLE
Add fork block height configuration to thorchain-package

### DIFF
--- a/examples/forking-enabled.yaml
+++ b/examples/forking-enabled.yaml
@@ -10,6 +10,7 @@ chains:
       enabled: true
       rpc: "https://rpc.ninerealms.com"
       chain_id: "thorchain-mainnet-v1"
+      height: 0  # 0 = latest, or specify specific block height like 22057352
       cache_enabled: true
       cache_size: 10000
       timeout: "60s"

--- a/src/network_launcher/network_launcher.star
+++ b/src/network_launcher/network_launcher.star
@@ -10,9 +10,10 @@ def launch_network(plan, genesis_files, parsed_args):
         thornode_args = ""
         if chain.get("forking", {}).get("enabled", False):
             forking_config = chain["forking"]
-            thornode_args = "--fork.rpc={} --fork.chain-id={} --fork.cache-enabled={} --fork.cache-size={} --fork.timeout={} --fork.gas-cost-per-fetch={}".format(
+            thornode_args = "--fork.rpc={} --fork.chain-id={} --fork.height={} --fork.cache-enabled={} --fork.cache-size={} --fork.timeout={} --fork.gas-cost-per-fetch={}".format(
                 forking_config.get("rpc", "https://rpc.ninerealms.com"),
                 forking_config.get("chain_id", "thorchain-mainnet-v1"),
+                forking_config.get("height", 0),
                 str(forking_config.get("cache_enabled", True)).lower(),
                 forking_config.get("cache_size", 10000),
                 forking_config.get("timeout", "60s"),

--- a/src/package_io/thorchain_defaults.json
+++ b/src/package_io/thorchain_defaults.json
@@ -91,6 +91,7 @@
     "enabled": false,
     "rpc": "https://rpc.ninerealms.com",
     "chain_id": "thorchain-mainnet-v1",
+    "height": 0,
     "cache_enabled": true,
     "cache_size": 10000,
     "timeout": "60s",


### PR DESCRIPTION
# Add fork block height configuration to thorchain-package

## Summary

This PR adds support for configuring the fork block height in thorchain-package deployments, similar to reth's `FORKING_BLOCK_HEIGHT` functionality. Users can now specify either:
- `height: 0` - Fork from the latest block (default behavior)  
- `height: 22057352` - Fork from a specific historical block height

The changes enable the thorchain-package to pass the `--fork.height` parameter to thornode during deployment, allowing for more precise control over the forking point for development and testing scenarios.

## Review & Testing Checklist for Human

- [ ] **Test end-to-end deployment** with both `height: 0` (latest) and a specific block height to ensure both configurations work correctly
- [ ] **Verify thornode image compatibility** - confirm the thornode image being used supports the `--fork.height` CLI flag (requires the companion thornode PR changes)
- [ ] **Test forking disabled mode** - ensure deployments with `forking.enabled: false` still work as expected
- [ ] **Validate parameter flow** - check that the height value correctly flows through: YAML config → defaults → network_launcher → thornode CLI args

**Recommended test plan:** Deploy using both `examples/forking-enabled.yaml` (with different height values) and `examples/forking-disabled.yaml` to verify all scenarios work end-to-end.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["examples/forking-enabled.yaml<br/>height: 0 or specific block"]:::minor-edit
    B["src/package_io/thorchain_defaults.json<br/>default height: 0"]:::minor-edit  
    C["src/network_launcher/network_launcher.star<br/>--fork.height={} in CLI args"]:::major-edit
    D["thornode process<br/>(requires --fork.height support)"]:::context
    
    A --> C
    B --> C  
    C --> D
    
    C -.->|"passes --fork.height parameter"| D
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#ADD8E6
classDef context fill:#FFFFFF
```

### Notes

- This PR coordinates with thornode changes that add the `--fork.height` CLI flag support
- Default behavior (height=0 = latest block) should be preserved to maintain backward compatibility
- The height parameter is separate from trust height (used for light client verification)
- Session reference: https://app.devin.ai/sessions/37edf9ea72a446e3b0edf7e280b061ae (requested by @tiljrd)