### PR TITLE
mimir: remove wget fallback in faucet funding; use curl-only

### DIFF
--- a/src/mimir-config/mimir_configurator.star
+++ b/src/mimir-config/mimir_configurator.star
@@ -46,9 +46,7 @@ def configure_mimir_values(plan, chain_config, node_info):
                     recipe=ExecRecipe(
                         command=[
                             "/bin/sh", "-lc",
-                            "curl -s -X POST http://{}-faucet:8090/fund/{} || wget -q -O- --post-data= '' http://{}-faucet:8090/fund/{} || true".format(
-                                chain_name,
-                                validator_addr,
+                            "curl -sf -X POST http://{}-faucet:8090/fund/{} || true".format(
                                 chain_name,
                                 validator_addr,
                             )


### PR DESCRIPTION
# mimir: remove wget fallback in faucet funding; use curl-only

## Summary
Removes the `wget` fallback from the MIMIR configurator's faucet funding command. The original command attempted `curl` first, then fell back to `wget` if curl failed. However, `wget` is not installed in the validator container, causing "/bin/sh: 1: wget: not found" errors during Kurtosis runs.

The fix simplifies the command to use only `curl -sf` (silent, fail on HTTP errors) with the existing `|| true` fallback to prevent breaking the overall configuration process.

## Review & Testing Checklist for Human
- [ ] **Test end-to-end validator funding**: Run `kurtosis clean -a` and `kurtosis run --enclave thor-fork . --args-file ./examples/forking-enabled.yaml`, verify "Funding validator via faucet" step completes without wget errors
- [ ] **Verify curl availability**: Confirm `curl` is available in validator containers (should be, since faucet service uses it)
- [ ] **Check funding success**: Ensure validator receives funds after the mimir configuration step completes

### Notes
- The `wget` command wasn't functional anyway due to missing binary in the container
- The `|| true` ensures funding failures don't break the entire network startup process
- This change was requested by @tiljrd to fix Kurtosis run failures

**Link to Devin run:** https://app.devin.ai/sessions/b462a603e78e408090ec243ab23a4e50  
**Requested by:** Til Jordan (@tiljrd)