### PR TITLE
Org rename: LZeroAnalytics → 0xBloctopus

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This package automates the deployment of complete THORChain networks through a c
 Deploy a default THORChain network:
 
 ```bash
-kurtosis run --enclave thorchain-testnet github.com/LZeroAnalytics/thorchain-package
+kurtosis run --enclave thorchain-testnet github.com/0xBloctopus/thorchain-package
 ```
 
 ### Custom Configuration
@@ -40,7 +40,7 @@ kurtosis run --enclave thorchain-testnet github.com/LZeroAnalytics/thorchain-pac
 Create a configuration file and deploy:
 
 ```bash
-kurtosis run --enclave thorchain-testnet github.com/LZeroAnalytics/thorchain-package --args-file config.yaml
+kurtosis run --enclave thorchain-testnet github.com/0xBloctopus/thorchain-package --args-file config.yaml
 ```
 
 Example minimal configuration:
@@ -138,7 +138,7 @@ Fork from mainnet state for realistic testing. Requires a forking-enabled THORNo
 ### Basic Deployment
 Use default configuration with a single validator:
 ```bash
-kurtosis run --enclave thorchain-testnet github.com/LZeroAnalytics/thorchain-package
+kurtosis run --enclave thorchain-testnet github.com/0xBloctopus/thorchain-package
 ```
 
 ### Prefunded Accounts


### PR DESCRIPTION
# Org rename: LZeroAnalytics → 0xBloctopus

## Summary
Updates GitHub organization references in README.md documentation from "LZeroAnalytics" to "0xBloctopus" as part of the broader organizational rename. Specifically updates three `kurtosis run` command examples to use the new organization name.

## Review & Testing Checklist for Human
- [ ] **Verify GitHub org rename is complete** - Confirm that `github.com/0xBloctopus/thorchain-package` actually exists and is accessible
- [ ] **Test kurtosis commands** - Run at least one of the updated kurtosis commands to ensure they work with the new org name: `kurtosis run --enclave test-thorchain github.com/0xBloctopus/thorchain-package`
- [ ] **Check kurtosis.yml** - Verify if `kurtosis.yml` in this repo also needs the org name updated (not included in this PR)

### Notes
- This is part of a larger organizational rename effort across multiple repositories
- Changes are purely documentation updates - no functional code changes
- Session requested by: Til Jordan (@tiljrd)
- Link to Devin run: https://app.devin.ai/sessions/c902258a44f043638d91d9f06ccef179