### PR TITLE
chore: bump thornode image: update to 1.0.23-23761879 (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ chains:
     app_version: "3.11.0"
     forking:
       enabled: true
-      image: "tiljordan/thornode-forking:1.0.22-23761879"
+      image: "tiljordan/thornode-forking:1.0.23-23761879"
       height: 23015000
     participants:
-      - image: "tiljordan/thornode-forking:1.0.22-23761879"
+      - image: "tiljordan/thornode-forking:1.0.23-23761879"
         count: 1
         account_balance: 1000000000000
         bond_amount: 500000000000

--- a/examples/cli-with-network.yaml
+++ b/examples/cli-with-network.yaml
@@ -7,7 +7,7 @@ chains:
     participants:
       - type: full
         count: 1
-        image: "tiljordan/thornode-forking:1.0.22-23761879"
+        image: "tiljordan/thornode-forking:1.0.23-23761879"
         account_balance: 1000000000000
         bond_amount: 500000000000
         min_cpu: 500

--- a/examples/forking-1.0.10.yaml
+++ b/examples/forking-1.0.10.yaml
@@ -2,7 +2,7 @@ chains:
   - name: thorchain
     type: thorchain
     participants:
-      - image: "tiljordan/thornode-forking:1.0.22-23761879"
+      - image: "tiljordan/thornode-forking:1.0.23-23761879"
         account_balance: 1000000000000000
         bond_amount: "300000000000000"
         count: 1

--- a/examples/forking-genesis.yaml
+++ b/examples/forking-genesis.yaml
@@ -7,13 +7,13 @@ chains:
 
     forking:
       enabled: true
-      image: "tiljordan/thornode-forking:1.0.22-23761879"
+      image: "tiljordan/thornode-forking:1.0.23-23761879"
       height: 23043758
 
     participants:
       - type: full
         count: 1
-        image: "tiljordan/thornode-forking:1.0.22-23761879"
+        image: "tiljordan/thornode-forking:1.0.23-23761879"
         account_balance: 1000000000000
         bond_amount: 500000000000
         min_cpu: 500

--- a/src/faucet/faucet_launcher.star
+++ b/src/faucet/faucet_launcher.star
@@ -30,7 +30,7 @@ def launch_faucet(plan, chain_name, chain_id, mnemonic, transfer_amount):
     )
 
     # Use thornode forking image to get thornode CLI in container
-    faucet_image = "tiljordan/thornode-forking:1.0.22-23761879"
+    faucet_image = "tiljordan/thornode-forking:1.0.23-23761879"
 
     # Launch the faucet service
     plan.add_service(

--- a/src/network_launcher/single_node_launcher.star
+++ b/src/network_launcher/single_node_launcher.star
@@ -9,7 +9,7 @@ def launch_single_node(plan, chain_cfg):
     config_folder = "/root/.thornode/config"
 
     forking_config = chain_cfg.get("forking", {})
-    forking_image = forking_config.get("image", "tiljordan/thornode-forking:1.0.22-23761879")
+    forking_image = forking_config.get("image", "tiljordan/thornode-forking:1.0.23-23761879")
 
     participant = chain_cfg["participants"][0]
     node_volume_size = participant.get("persistent_size_mb", chain_cfg.get("node_persistent_size_mb", 16384))

--- a/src/package_io/thorchain_defaults.json
+++ b/src/package_io/thorchain_defaults.json
@@ -54,7 +54,7 @@
     {
       "type": "full",
       "count": 1,
-      "image": "tiljordan/thornode-forking:1.0.22-23761879",
+      "image": "tiljordan/thornode-forking:1.0.23-23761879",
       "account_balance": 1000000000000,
       "bond_amount": 500000000000,
       "min_cpu": 1000,
@@ -68,7 +68,7 @@
   ],
   "forking": {
     "enabled": true,
-    "image": "tiljordan/thornode-forking:1.0.22-23761879",
+    "image": "tiljordan/thornode-forking:1.0.23-23761879",
     "grpc": "grpc.thor.pfc.zone:443",
     "chain_id": "thorchain-1",
     "height": 23043758,

--- a/src/toolchain-cli/Dockerfile
+++ b/src/toolchain-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiljordan/thornode-forking:1.0.22-23761879
+FROM tiljordan/thornode-forking:1.0.23-23761879
 
 SHELL ["/bin/bash", "-lc"]
 


### PR DESCRIPTION
Automated: bump image to `tiljordan/thornode-forking:1.0.23-23761879` on base **main**. Automated weekly bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the thornode-forking Docker image version from 1.0.22-23761879 to 1.0.23-23761879 across documentation, configuration examples, network launcher implementations, default package settings, and the toolchain build container. Applied consistently throughout the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->