### PR TITLE
chore: bump thornode image: update to 1.0.26-23761879 (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ chains:
     app_version: "3.11.0"
     forking:
       enabled: true
-      image: "tiljordan/thornode-forking:1.0.25-23761879"
+      image: "tiljordan/thornode-forking:1.0.26-23761879"
       height: 23015000
     participants:
-      - image: "tiljordan/thornode-forking:1.0.25-23761879"
+      - image: "tiljordan/thornode-forking:1.0.26-23761879"
         count: 1
         account_balance: 1000000000000
         bond_amount: 500000000000

--- a/examples/cli-with-network.yaml
+++ b/examples/cli-with-network.yaml
@@ -7,7 +7,7 @@ chains:
     participants:
       - type: full
         count: 1
-        image: "tiljordan/thornode-forking:1.0.25-23761879"
+        image: "tiljordan/thornode-forking:1.0.26-23761879"
         account_balance: 1000000000000
         bond_amount: 500000000000
         min_cpu: 500

--- a/examples/forking-1.0.10.yaml
+++ b/examples/forking-1.0.10.yaml
@@ -2,7 +2,7 @@ chains:
   - name: thorchain
     type: thorchain
     participants:
-      - image: "tiljordan/thornode-forking:1.0.25-23761879"
+      - image: "tiljordan/thornode-forking:1.0.26-23761879"
         account_balance: 1000000000000000
         bond_amount: "300000000000000"
         count: 1

--- a/examples/forking-genesis.yaml
+++ b/examples/forking-genesis.yaml
@@ -7,13 +7,13 @@ chains:
 
     forking:
       enabled: true
-      image: "tiljordan/thornode-forking:1.0.25-23761879"
+      image: "tiljordan/thornode-forking:1.0.26-23761879"
       height: 23043758
 
     participants:
       - type: full
         count: 1
-        image: "tiljordan/thornode-forking:1.0.25-23761879"
+        image: "tiljordan/thornode-forking:1.0.26-23761879"
         account_balance: 1000000000000
         bond_amount: 500000000000
         min_cpu: 500

--- a/src/faucet/faucet_launcher.star
+++ b/src/faucet/faucet_launcher.star
@@ -30,7 +30,7 @@ def launch_faucet(plan, chain_name, chain_id, mnemonic, transfer_amount):
     )
 
     # Use thornode forking image to get thornode CLI in container
-    faucet_image = "tiljordan/thornode-forking:1.0.25-23761879"
+    faucet_image = "tiljordan/thornode-forking:1.0.26-23761879"
 
     # Launch the faucet service
     plan.add_service(

--- a/src/network_launcher/single_node_launcher.star
+++ b/src/network_launcher/single_node_launcher.star
@@ -9,7 +9,7 @@ def launch_single_node(plan, chain_cfg):
     config_folder = "/root/.thornode/config"
 
     forking_config = chain_cfg.get("forking", {})
-    forking_image = forking_config.get("image", "tiljordan/thornode-forking:1.0.25-23761879")
+    forking_image = forking_config.get("image", "tiljordan/thornode-forking:1.0.26-23761879")
 
     participant = chain_cfg["participants"][0]
     node_volume_size = participant.get("persistent_size_mb", chain_cfg.get("node_persistent_size_mb", 16384))

--- a/src/package_io/thorchain_defaults.json
+++ b/src/package_io/thorchain_defaults.json
@@ -54,7 +54,7 @@
     {
       "type": "full",
       "count": 1,
-      "image": "tiljordan/thornode-forking:1.0.25-23761879",
+      "image": "tiljordan/thornode-forking:1.0.26-23761879",
       "account_balance": 1000000000000,
       "bond_amount": 500000000000,
       "min_cpu": 1000,
@@ -68,7 +68,7 @@
   ],
   "forking": {
     "enabled": true,
-    "image": "tiljordan/thornode-forking:1.0.25-23761879",
+    "image": "tiljordan/thornode-forking:1.0.26-23761879",
     "grpc": "grpc.thor.pfc.zone:443",
     "chain_id": "thorchain-1",
     "height": 23043758,

--- a/src/toolchain-cli/Dockerfile
+++ b/src/toolchain-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiljordan/thornode-forking:1.0.25-23761879
+FROM tiljordan/thornode-forking:1.0.26-23761879
 
 SHELL ["/bin/bash", "-lc"]
 


### PR DESCRIPTION
### **User description**
Automated: bump image to `tiljordan/thornode-forking:1.0.26-23761879` on base **main**. Automated weekly bump.


___

### **PR Type**
Other


___

### **Description**
- Update thornode-forking image from 1.0.25 to 1.0.26

- Bump applied across configuration files and examples

- Update default image reference in toolchain Dockerfile


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["thornode-forking<br/>1.0.25-23761879"] -- "upgrade to" --> B["thornode-forking<br/>1.0.26-23761879"]
  B --> C["Configuration Files"]
  B --> D["Example Files"]
  B --> E["Dockerfile"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README documentation image versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update forking image reference from 1.0.25 to 1.0.26<br> <li> Update participants image reference from 1.0.25 to 1.0.26</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cli-with-network.yaml</strong><dd><code>Update CLI example image version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/cli-with-network.yaml

- Update participant image from 1.0.25 to 1.0.26


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-586bb9fd951ac18bf6bf6ce46be6a5f198c96fc3af128573d0a0196612b3d4fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>forking-1.0.10.yaml</strong><dd><code>Update forking example image version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/forking-1.0.10.yaml

- Update participant image from 1.0.25 to 1.0.26


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-6dfb8da6c49f5cf44817c260f39e1625e8e25cb4140a6f7d4e6bc911bc5e31dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>forking-genesis.yaml</strong><dd><code>Update forking genesis example images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/forking-genesis.yaml

<ul><li>Update forking image from 1.0.25 to 1.0.26<br> <li> Update participant image from 1.0.25 to 1.0.26</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-d1ee87762a8bc1fa0f8e416d838844fe5c3d3fd42fabadfd1d80ef3464ff25e9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>faucet_launcher.star</strong><dd><code>Update faucet launcher image version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/faucet/faucet_launcher.star

- Update faucet_image variable from 1.0.25 to 1.0.26


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-789cbb711a5b288c81a73d534430322a552b88d1744a98bbbea3b1e35f5f8989">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>single_node_launcher.star</strong><dd><code>Update single node launcher default image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/network_launcher/single_node_launcher.star

- Update default forking_image from 1.0.25 to 1.0.26


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-87464247c2919222ef9eb51bf421599a619ff9276d5d36bdc08cd60447f9da63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>thorchain_defaults.json</strong><dd><code>Update thorchain defaults image references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/package_io/thorchain_defaults.json

<ul><li>Update participant image from 1.0.25 to 1.0.26<br> <li> Update forking image from 1.0.25 to 1.0.26</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-dfdacf391ee0fb0bf1e76bf538ff43e278dbca43dc58770ce73d56fc9834fc1b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update toolchain CLI base image version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/toolchain-cli/Dockerfile

- Update base image FROM clause from 1.0.25 to 1.0.26


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thorchain-package/pull/81/files#diff-6c458c4c6a3e71815157e516042885cb9115eaa50f5aba47bf27ba15d8c9817c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Thornode forking component image version across configuration files and Docker setup for improved compatibility and service stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->